### PR TITLE
change package of package name to net.discdd.mail

### DIFF
--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -36,14 +36,14 @@ dependencies {
 }
 
 android {
-    namespace = "net.discdd.k9"
+    namespace = "net.discdd.mail"
 
     defaultConfig {
-        applicationId = "net.discdd.k9"
-        testApplicationId = "net.discdd.k9.tests"
+        applicationId = "net.discdd.mail"
+        testApplicationId = "net.discdd.mail.tests"
 
-        versionCode = 39007
-        versionName = "6.905-DDD-alpha2"
+        versionCode = 39008
+        versionName = "6.905-DDD-alpha3"
 
         minSdk = 33
 

--- a/app-k9mail/build.gradle.kts
+++ b/app-k9mail/build.gradle.kts
@@ -42,8 +42,8 @@ android {
         applicationId = "net.discdd.mail"
         testApplicationId = "net.discdd.mail.tests"
 
-        versionCode = 39008
-        versionName = "6.905-DDD-alpha3"
+        versionCode = 39007
+        versionName = "6.905-DDD-alpha2"
 
         minSdk = 33
 

--- a/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -2,7 +2,7 @@ package app.k9mail.auth
 
 import app.k9mail.core.common.oauth.OAuthConfiguration
 import app.k9mail.core.common.oauth.OAuthConfigurationFactory
-import net.discdd.k9.BuildConfig
+import net.discdd.mail.BuildConfig
 
 @Suppress("ktlint:standard:max-line-length")
 class K9OAuthConfigurationFactory : OAuthConfigurationFactory {

--- a/app-k9mail/src/main/AndroidManifest.xml
+++ b/app-k9mail/src/main/AndroidManifest.xml
@@ -5,10 +5,6 @@
     <queries>
         <provider android:authorities="net.discdd.provider.datastoreprovider" />
     </queries>
-    <uses-permission
-        android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ" />
-    <uses-permission
-        android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_WRITE" />
     <application
         android:name="app.k9mail.K9App"
         android:icon="@drawable/ic_launcher"

--- a/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/K9KoinModule.kt
@@ -13,7 +13,7 @@ import com.fsck.k9.AppConfig
 import com.fsck.k9.activity.MessageCompose
 import com.fsck.k9.provider.UnreadWidgetProvider
 import com.fsck.k9.widget.list.MessageListWidgetProvider
-import net.discdd.k9.BuildConfig
+import net.discdd.mail.BuildConfig
 import org.koin.android.ext.koin.androidContext
 import org.koin.core.qualifier.named
 import org.koin.dsl.module

--- a/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
+++ b/app-k9mail/src/main/kotlin/app/k9mail/provider/K9AppNameProvider.kt
@@ -2,7 +2,7 @@ package app.k9mail.provider
 
 import android.content.Context
 import app.k9mail.core.common.provider.AppNameProvider
-import net.discdd.k9.R
+import net.discdd.mail.R
 
 class K9AppNameProvider(
     context: Context,

--- a/app-k9mail/src/main/res/values-ar/strings.xml
+++ b/app-k9mail/src/main/res/values-ar/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">بريد K-9</string>
+    <string name="app_name">بريد DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-az/strings.xml
+++ b/app-k9mail/src/main/res/values-az/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-be/strings.xml
+++ b/app-k9mail/src/main/res/values-be/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Пошта K-9</string>
+    <string name="app_name">Пошта DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-bg/strings.xml
+++ b/app-k9mail/src/main/res/values-bg/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-br/strings.xml
+++ b/app-k9mail/src/main/res/values-br/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-bs/strings.xml
+++ b/app-k9mail/src/main/res/values-bs/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ca/strings.xml
+++ b/app-k9mail/src/main/res/values-ca/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-co/strings.xml
+++ b/app-k9mail/src/main/res/values-co/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-cs/strings.xml
+++ b/app-k9mail/src/main/res/values-cs/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-cy/strings.xml
+++ b/app-k9mail/src/main/res/values-cy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-da/strings.xml
+++ b/app-k9mail/src/main/res/values-da/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-de/strings.xml
+++ b/app-k9mail/src/main/res/values-de/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-el/strings.xml
+++ b/app-k9mail/src/main/res/values-el/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-en-rGB/strings.xml
+++ b/app-k9mail/src/main/res/values-en-rGB/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-eo/strings.xml
+++ b/app-k9mail/src/main/res/values-eo/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Retpoŝtilo</string>
+    <string name="app_name">DDD Retpoŝtilo</string>
 </resources>

--- a/app-k9mail/src/main/res/values-es/strings.xml
+++ b/app-k9mail/src/main/res/values-es/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-et/strings.xml
+++ b/app-k9mail/src/main/res/values-et/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-eu/strings.xml
+++ b/app-k9mail/src/main/res/values-eu/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-fa/strings.xml
+++ b/app-k9mail/src/main/res/values-fa/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">نامهٔ کِی۹</string>
 </resources>

--- a/app-k9mail/src/main/res/values-fi/strings.xml
+++ b/app-k9mail/src/main/res/values-fi/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">@string/app_name</string>
 </resources>

--- a/app-k9mail/src/main/res/values-fr/strings.xml
+++ b/app-k9mail/src/main/res/values-fr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Courriel K-9 Mail</string>
+    <string name="app_name">Courriel DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-fy/strings.xml
+++ b/app-k9mail/src/main/res/values-fy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-gd/strings.xml
+++ b/app-k9mail/src/main/res/values-gd/strings.xml
@@ -1,4 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Post</string>
 </resources>

--- a/app-k9mail/src/main/res/values-gl/strings.xml
+++ b/app-k9mail/src/main/res/values-gl/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-hi/strings.xml
+++ b/app-k9mail/src/main/res/values-hi/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">के-9 मेल</string>
+    <string name="app_name">DDD मेल</string>
 </resources>

--- a/app-k9mail/src/main/res/values-hr/strings.xml
+++ b/app-k9mail/src/main/res/values-hr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-hu/strings.xml
+++ b/app-k9mail/src/main/res/values-hu/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-hy/strings.xml
+++ b/app-k9mail/src/main/res/values-hy/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Նամակ</string>
+    <string name="app_name">DDD Նամակ</string>
 </resources>

--- a/app-k9mail/src/main/res/values-in/strings.xml
+++ b/app-k9mail/src/main/res/values-in/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-is/strings.xml
+++ b/app-k9mail/src/main/res/values-is/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 - Póstur</string>
+    <string name="app_name">DDD - Póstur</string>
 </resources>

--- a/app-k9mail/src/main/res/values-it/strings.xml
+++ b/app-k9mail/src/main/res/values-it/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-iw/strings.xml
+++ b/app-k9mail/src/main/res/values-iw/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">דוא\"ל K-9</string>
+    <string name="app_name">דוא\"ל DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ja/strings.xml
+++ b/app-k9mail/src/main/res/values-ja/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ka/strings.xml
+++ b/app-k9mail/src/main/res/values-ka/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ko/strings.xml
+++ b/app-k9mail/src/main/res/values-ko/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 메일</string>
+    <string name="app_name">DDD 메일</string>
 </resources>

--- a/app-k9mail/src/main/res/values-lt/strings.xml
+++ b/app-k9mail/src/main/res/values-lt/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 paštas</string>
+    <string name="app_name">DDD paštas</string>
 </resources>

--- a/app-k9mail/src/main/res/values-lv/strings.xml
+++ b/app-k9mail/src/main/res/values-lv/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 pasts</string>
+    <string name="app_name">DDD pasts</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ml/strings.xml
+++ b/app-k9mail/src/main/res/values-ml/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-nb/strings.xml
+++ b/app-k9mail/src/main/res/values-nb/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 e-post</string>
+    <string name="app_name">DDD e-post</string>
 </resources>

--- a/app-k9mail/src/main/res/values-nl/strings.xml
+++ b/app-k9mail/src/main/res/values-nl/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-nn/strings.xml
+++ b/app-k9mail/src/main/res/values-nn/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 E-post</string>
+    <string name="app_name">DDD E-post</string>
 </resources>

--- a/app-k9mail/src/main/res/values-pl/strings.xml
+++ b/app-k9mail/src/main/res/values-pl/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-pt-rBR/strings.xml
+++ b/app-k9mail/src/main/res/values-pt-rBR/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-pt-rPT/strings.xml
+++ b/app-k9mail/src/main/res/values-pt-rPT/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ro/strings.xml
+++ b/app-k9mail/src/main/res/values-ro/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ru/strings.xml
+++ b/app-k9mail/src/main/res/values-ru/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Почта K-9</string>
+    <string name="app_name">Почта DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-sk/strings.xml
+++ b/app-k9mail/src/main/res/values-sk/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-sl/strings.xml
+++ b/app-k9mail/src/main/res/values-sl/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Pošta K-9</string>
+    <string name="app_name">Pošta DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-sq/strings.xml
+++ b/app-k9mail/src/main/res/values-sq/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-sr/strings.xml
+++ b/app-k9mail/src/main/res/values-sr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">К-9 Пошта</string>
+    <string name="app_name">DDD Пошта</string>
 </resources>

--- a/app-k9mail/src/main/res/values-sv/strings.xml
+++ b/app-k9mail/src/main/res/values-sv/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-ta-rIN/strings.xml
+++ b/app-k9mail/src/main/res/values-ta-rIN/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 அஞ்சல்</string>
+    <string name="app_name">DDD அஞ்சல்</string>
 </resources>

--- a/app-k9mail/src/main/res/values-tr/strings.xml
+++ b/app-k9mail/src/main/res/values-tr/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Posta</string>
+    <string name="app_name">DDD Posta</string>
 </resources>

--- a/app-k9mail/src/main/res/values-uk/strings.xml
+++ b/app-k9mail/src/main/res/values-uk/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/app-k9mail/src/main/res/values-vi/strings.xml
+++ b/app-k9mail/src/main/res/values-vi/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">Thư K-9</string>
+    <string name="app_name">Thư DDD</string>
 </resources>

--- a/app-k9mail/src/main/res/values-zh-rCN/strings.xml
+++ b/app-k9mail/src/main/res/values-zh-rCN/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 邮件</string>
+    <string name="app_name">DDD 邮件</string>
 </resources>

--- a/app-k9mail/src/main/res/values-zh-rTW/strings.xml
+++ b/app-k9mail/src/main/res/values-zh-rTW/strings.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <string name="app_name">K-9 Mail</string>
+    <string name="app_name">DDD Mail</string>
 </resources>

--- a/backend/ddd/src/main/AndroidManifest.xml
+++ b/backend/ddd/src/main/AndroidManifest.xml
@@ -2,13 +2,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:installLocation="auto">
-    <uses-permission
-        android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_READ"
-        android:protectionLevel="normal" />
-    <uses-permission
-        android:name="net.discdd.bundleclient.permission.MESSAGE_PROVIDER_WRITE"
-        android:protectionLevel="normal" />
-    <uses-permission android:name="android.permission.SCHEDULE_EXACT_ALARM"/>
 
     <queries>
         <provider android:authorities="net.discdd.provider.datastoreprovider" />


### PR DESCRIPTION
avoid K9 branding as requested by thunderbird.

the most disruptive change is the android package name is changing from net.discdd.k9 to net.discdd.mail.