### PR TITLE
DDD-mail: make sure onboarding always uses DDD onboarding

### DIFF
--- a/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/debug/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -6,7 +6,6 @@ import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 @Suppress("ktlint:standard:max-line-length")
 class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
     override fun createConfigurations(): Map<List<String>, OAuthConfiguration> {
-
         return mapOf()
     }
 }

--- a/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
+++ b/app-k9mail/src/release/kotlin/app/k9mail/auth/K9OAuthConfigurationFactory.kt
@@ -6,7 +6,6 @@ import app.k9mail.core.common.oauth.OAuthConfigurationFactory
 @Suppress("ktlint:standard:max-line-length")
 class K9OAuthConfigurationFactory : OAuthConfigurationFactory {
     override fun createConfigurations(): Map<List<String>, OAuthConfiguration> {
-        return mapOf(
-        )
+        return mapOf()
     }
 }

--- a/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
+++ b/feature/launcher/src/main/kotlin/app/k9mail/feature/launcher/FeatureLauncherActivity.kt
@@ -11,7 +11,6 @@ import app.k9mail.feature.account.edit.navigation.NAVIGATION_ROUTE_ACCOUNT_EDIT_
 import app.k9mail.feature.account.edit.navigation.withAccountUuid
 import app.k9mail.feature.account.setup.navigation.NAVIGATION_ROUTE_ACCOUNT_SETUP
 import app.k9mail.feature.launcher.ui.FeatureLauncherApp
-import app.k9mail.feature.onboarding.main.navigation.NAVIGATION_ROUTE_ONBOARDING
 import com.fsck.k9.ui.base.K9Activity
 import net.discdd.k9.onboarding.navigation.NAVIGATION_ROUTE_DDD_ONBOARDING
 
@@ -38,7 +37,7 @@ class FeatureLauncherActivity : K9Activity() {
 
         @JvmStatic fun launchOnboarding(context: Context) {
             val intent = Intent(context, FeatureLauncherActivity::class.java).apply {
-                data = NAVIGATION_ROUTE_ONBOARDING.toDeepLinkUri()
+                data = NAVIGATION_ROUTE_DDD_ONBOARDING.toDeepLinkUri()
                 flags = Intent.FLAG_ACTIVITY_NEW_TASK or Intent.FLAG_ACTIVITY_CLEAR_TASK
             }
             context.startActivity(intent)


### PR DESCRIPTION
we need to make sure our onboarding is followed after after the account is deleted.

hook into the mail routing so that DDD onboarding is always used.