### PR TITLE
Add attachment size limit handling in MessageCompose and AttachmentPr…

### DIFF
--- a/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
+++ b/legacy/ui/legacy/src/main/java/com/fsck/k9/activity/MessageCompose.java
@@ -1890,6 +1890,11 @@ public class MessageCompose extends K9Activity implements OnClickListener,
         }
 
         @Override
+        public void showAttachmentSizeLimitExceeded() {
+            Toast.makeText(MessageCompose.this, R.string.attachment_size_limit_exceeded, Toast.LENGTH_LONG).show();
+        }
+
+        @Override
         public void showMissingAttachmentsPartialMessageForwardWarning() {
             Toast.makeText(MessageCompose.this,
                     getString(R.string.message_compose_attachments_forward_toast), Toast.LENGTH_LONG).show();

--- a/legacy/ui/legacy/src/main/res/values/strings.xml
+++ b/legacy/ui/legacy/src/main/res/values/strings.xml
@@ -202,6 +202,7 @@
     <string name="error_contact_address_not_found">No email address could be found for this contact.</string>
     <string name="message_compose_attachments_skipped_toast">Some attachments cannot be forwarded because they have not been downloaded.</string>
     <string name="message_compose_attachments_forward_toast">The message cannot be forwarded because some attachments have not been downloaded.</string>
+    <string name="attachment_size_limit_exceeded">Cannot attach file - message size would exceed 20MB limit</string>
     <string name="message_compose_show_quoted_text_action">Include quoted message</string>
     <string name="message_compose_description_delete_quoted_text">Remove quoted text</string>
     <string name="message_compose_description_edit_quoted_text">Edit quoted text</string>


### PR DESCRIPTION
- Introduced a 20MB size limit for message attachments.
- Implemented logic to check if adding a new attachment would exceed the size limit.
- Added user feedback via a toast message when the size limit is exceeded.
- Updated strings.xml to include a new message for size limit exceeded scenario.

