### PR TITLE
Implemented Error Screen Which Displays if BundleClient is Not Installed.

### DIFF
--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
@@ -10,12 +10,15 @@ import net.discdd.k9.onboarding.ui.login.LoginScreen
 import net.discdd.k9.onboarding.ui.login.LoginViewModel
 import net.discdd.k9.onboarding.ui.pending.PendingScreen
 import net.discdd.k9.onboarding.ui.register.RegisterScreen
+import net.discdd.k9.onboarding.ui.error.ErrorScreen
 import net.discdd.k9.onboarding.ui.register.RegisterViewModel
 import org.koin.androidx.compose.koinViewModel
 
 private const val NESTED_NAVIGATION_ROUTE_REGISTER = "register"
 private const val NESTED_NAVIGATION_ROUTE_LOGIN = "login"
 private const val NESTED_NAVIGATION_ROUTE_PENDING = "pending"
+
+private const val NESTED_NAVIGATION_ROUTE_ERROR = "errorScreen"
 
 private fun NavController.navigateToRegister() {
     navigate(NESTED_NAVIGATION_ROUTE_REGISTER)
@@ -25,6 +28,10 @@ fun NavController.navigateToLogin() {
     navigate(NESTED_NAVIGATION_ROUTE_LOGIN)
 }
 
+fun NavController.navigateToErrorState() {
+    Log.d("Error", "Client needs to be installed")
+    navigate(NESTED_NAVIGATION_ROUTE_ERROR)
+}
 private fun NavController.navigateToPending() {
     Log.d("DDDOnboarding", "navigating to pending")
     navigate(NESTED_NAVIGATION_ROUTE_PENDING)
@@ -39,6 +46,9 @@ fun OnboardingNavHost(
         navController = navController,
         startDestination = NESTED_NAVIGATION_ROUTE_LOGIN,
     ) {
+        composable(route = NESTED_NAVIGATION_ROUTE_ERROR) {
+            ErrorScreen()
+    }
         composable(route = NESTED_NAVIGATION_ROUTE_LOGIN) {
             LoginScreen(
                 onRegisterClick = { navController.navigateToRegister() },
@@ -47,6 +57,7 @@ fun OnboardingNavHost(
                 onFinish = { createdAccountUuid: String ->
                     onFinish(createdAccountUuid)
                 },
+                onErrorState = { navController.navigateToErrorState() },
             )
         }
         composable(route = NESTED_NAVIGATION_ROUTE_REGISTER) {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
@@ -29,7 +29,6 @@ fun NavController.navigateToLogin() {
 }
 
 fun NavController.navigateToErrorState() {
-    Log.d("Error", "Client needs to be installed")
     navigate(NESTED_NAVIGATION_ROUTE_ERROR)
 }
 private fun NavController.navigateToPending() {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/navigation/OnboardingNavHost.kt
@@ -6,11 +6,11 @@ import androidx.navigation.NavController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
+import net.discdd.k9.onboarding.ui.error.ErrorScreen
 import net.discdd.k9.onboarding.ui.login.LoginScreen
 import net.discdd.k9.onboarding.ui.login.LoginViewModel
 import net.discdd.k9.onboarding.ui.pending.PendingScreen
 import net.discdd.k9.onboarding.ui.register.RegisterScreen
-import net.discdd.k9.onboarding.ui.error.ErrorScreen
 import net.discdd.k9.onboarding.ui.register.RegisterViewModel
 import org.koin.androidx.compose.koinViewModel
 
@@ -48,7 +48,7 @@ fun OnboardingNavHost(
     ) {
         composable(route = NESTED_NAVIGATION_ROUTE_ERROR) {
             ErrorScreen()
-    }
+        }
         composable(route = NESTED_NAVIGATION_ROUTE_LOGIN) {
             LoginScreen(
                 onRegisterClick = { navController.navigateToRegister() },

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepository.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepository.kt
@@ -17,6 +17,8 @@ interface AuthRepository {
 
     var authRepositoryListener: AuthRepositoryListener?
 
+    suspend fun checkClientStatus(): Boolean
+
     suspend fun getState(): Pair<AuthState, ControlAdu?>
 
     suspend fun logout()

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -40,7 +40,7 @@ class AuthRepositoryImpl(
     private fun isBundleClientInstalled(context: Context): Boolean {
         val pm = context.packageManager
         return try {
-            if (Build.VERSION.SDK_INT >= 33) {
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
                 // ✅ use the nested flags type
                 pm.getPackageInfo(
                     BUNDLE_CLIENT_PACKAGE,

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -44,7 +44,7 @@ class AuthRepositoryImpl(
                 // ✅ use the nested flags type
                 pm.getPackageInfo(
                     BUNDLE_CLIENT_PACKAGE,
-                    PackageManager.PackageInfoFlags.of(0)
+                    PackageManager.PackageInfoFlags.of(0),
                 )
             } else {
                 @Suppress("DEPRECATION")
@@ -55,7 +55,6 @@ class AuthRepositoryImpl(
             false
         }
     }
-
 
     override suspend fun getState(): Pair<AuthState, ControlAdu?> = withContext(Dispatchers.IO) {
         getAckAdu()?.run {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -34,7 +34,7 @@ class AuthRepositoryImpl(
     }
 
     override suspend fun checkClientStatus(): Boolean {
-        return dddClientAdapter.getClientId() != null || isBundleClientInstalled(context)
+        return dddClientAdapter.getClientId() != null && isBundleClientInstalled(context)
     }
 
     private fun isBundleClientInstalled(context: Context): Boolean {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -41,7 +41,6 @@ class AuthRepositoryImpl(
         val pm = context.packageManager
         return try {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-                // ✅ use the nested flags type
                 pm.getPackageInfo(
                     BUNDLE_CLIENT_PACKAGE,
                     PackageManager.PackageInfoFlags.of(0),

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -1,6 +1,8 @@
 package net.discdd.k9.onboarding.repository
 
 import android.content.Context
+import android.content.pm.PackageManager
+import android.os.Build
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 import net.discdd.adapter.DDDClientAdapter
@@ -8,6 +10,7 @@ import net.discdd.app.k9.common.ControlAdu
 import net.discdd.k9.onboarding.repository.AuthRepository.AuthState
 import net.discdd.k9.onboarding.util.AuthStateConfig
 
+private const val BUNDLE_CLIENT_PACKAGE = "net.discdd.bundleclient"
 class AuthRepositoryImpl(
     private val authStateConfig: AuthStateConfig,
     private val context: Context,
@@ -29,6 +32,30 @@ class AuthRepositoryImpl(
             authRepositoryListener?.onAuthStateChanged()
         })
     }
+
+    override suspend fun checkClientStatus(): Boolean {
+        return dddClientAdapter.getClientId() != null || isBundleClientInstalled(context)
+    }
+
+    private fun isBundleClientInstalled(context: Context): Boolean {
+        val pm = context.packageManager
+        return try {
+            if (Build.VERSION.SDK_INT >= 33) {
+                // ✅ use the nested flags type
+                pm.getPackageInfo(
+                    BUNDLE_CLIENT_PACKAGE,
+                    PackageManager.PackageInfoFlags.of(0)
+                )
+            } else {
+                @Suppress("DEPRECATION")
+                pm.getPackageInfo(BUNDLE_CLIENT_PACKAGE, 0)
+            }
+            true
+        } catch (_: PackageManager.NameNotFoundException) {
+            false
+        }
+    }
+
 
     override suspend fun getState(): Pair<AuthState, ControlAdu?> = withContext(Dispatchers.IO) {
         getAckAdu()?.run {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
@@ -11,10 +11,10 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 
 @Composable
-fun ErrorScreen() {
+fun ErrorScreen(modifier: Modifier = Modifier) {
     Surface(modifier = Modifier.fillMaxSize()) {
         Box(
-            modifier = Modifier
+            modifier = modifier
                 .fillMaxSize()
                 .padding(32.dp),
             contentAlignment = Alignment.Center,

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
@@ -12,9 +12,9 @@ import androidx.compose.ui.unit.dp
 
 @Composable
 fun ErrorScreen(modifier: Modifier = Modifier) {
-    Surface(modifier = Modifier.fillMaxSize()) {
+    Surface(modifier = modifier) {
         Box(
-            modifier = modifier
+            modifier = Modifier
                 .fillMaxSize()
                 .padding(32.dp),
             contentAlignment = Alignment.Center,

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
@@ -1,0 +1,27 @@
+package net.discdd.k9.onboarding.ui.error
+import androidx.compose.foundation.layout.*
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun ErrorScreen() {
+    Surface(modifier = Modifier.fillMaxSize()) {
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(32.dp),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = "This mail app cannot function without the DDD Client app.\n\nPlease install the DDD Client app and relaunch!",
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.error
+            )
+        }
+    }
+}

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/error/ErrorScreen.kt
@@ -1,5 +1,7 @@
 package net.discdd.k9.onboarding.ui.error
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -15,12 +17,13 @@ fun ErrorScreen() {
             modifier = Modifier
                 .fillMaxSize()
                 .padding(32.dp),
-            contentAlignment = Alignment.Center
+            contentAlignment = Alignment.Center,
         ) {
             Text(
-                text = "This mail app cannot function without the DDD Client app.\n\nPlease install the DDD Client app and relaunch!",
+                text = "This mail app cannot function without the DDD Client app.\n\n" +
+                    "Please install the DDD Client app and relaunch!",
                 style = MaterialTheme.typography.bodyLarge,
-                color = MaterialTheme.colorScheme.error
+                color = MaterialTheme.colorScheme.error,
             )
         }
     }

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginContract.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginContract.kt
@@ -41,6 +41,8 @@ interface LoginContract {
 
     sealed interface Effect {
         data object OnPendingState : Effect
+
+        data object onErrorState : Effect
         data class OnLoggedInState(val accountUuid: AccountUuid) : Effect
         data class OnError(val error: kotlin.Error) : LoginContract.Effect
     }

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginContract.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginContract.kt
@@ -42,7 +42,7 @@ interface LoginContract {
     sealed interface Effect {
         data object OnPendingState : Effect
 
-        data object onErrorState : Effect
+        data object OnErrorState : Effect
         data class OnLoggedInState(val accountUuid: AccountUuid) : Effect
         data class OnError(val error: kotlin.Error) : LoginContract.Effect
     }

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginScreen.kt
@@ -31,7 +31,7 @@ fun LoginScreen(
             Log.d("k9", "in effect: $effect")
             when (effect) {
                 Effect.OnPendingState -> onPendingState()
-                Effect.onErrorState -> onErrorState();
+                Effect.OnErrorState -> onErrorState()
                 is Effect.OnLoggedInState -> onFinish(effect.accountUuid.value)
                 is Effect.OnError -> {
                     showToast(context, effect.error.message)

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginScreen.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginScreen.kt
@@ -15,6 +15,7 @@ fun LoginScreen(
     onRegisterClick: () -> Unit,
     viewModel: LoginViewModel,
     onPendingState: () -> Unit,
+    onErrorState: () -> Unit,
     onFinish: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
@@ -30,6 +31,7 @@ fun LoginScreen(
             Log.d("k9", "in effect: $effect")
             when (effect) {
                 Effect.OnPendingState -> onPendingState()
+                Effect.onErrorState -> onErrorState();
                 is Effect.OnLoggedInState -> onFinish(effect.accountUuid.value)
                 is Effect.OnError -> {
                     showToast(context, effect.error.message)

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
@@ -19,7 +19,6 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
-import net.discdd.adapter.DDDClientAdapter
 import net.discdd.app.k9.common.ControlAdu
 import net.discdd.k9.onboarding.repository.AuthRepository
 import net.discdd.k9.onboarding.repository.AuthRepository.AuthState
@@ -164,7 +163,7 @@ class LoginViewModel(
         Log.d("k9", "client error")
         viewModelScope.coroutineContext.cancelChildren()
         viewModelScope.launch {
-            _effectFlow.emit(Effect.onErrorState)
+            _effectFlow.emit(Effect.OnErrorState)
         }
     }
     private fun navigatePending() {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
@@ -19,6 +19,7 @@ import kotlinx.coroutines.flow.asSharedFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import net.discdd.adapter.DDDClientAdapter
 import net.discdd.app.k9.common.ControlAdu
 import net.discdd.k9.onboarding.repository.AuthRepository
 import net.discdd.k9.onboarding.repository.AuthRepository.AuthState
@@ -50,6 +51,10 @@ class LoginViewModel(
     }
 
     private suspend fun checkAuthState() {
+        if (!(authRepository.checkClientStatus())) {
+            Log.d("checkAuthState", "Client Does Not Exist")
+            clientError()
+        }
         val (state, adu) = authRepository.getState()
         if (state == AuthState.PENDING) {
             Log.d("LoginViewModel", "state $state")
@@ -155,6 +160,13 @@ class LoginViewModel(
         }
     }
 
+    private fun clientError() {
+        Log.d("k9", "client error")
+        viewModelScope.coroutineContext.cancelChildren()
+        viewModelScope.launch {
+            _effectFlow.emit(Effect.onErrorState)
+        }
+    }
     private fun navigatePending() {
         Log.d("k9", "navigate pending")
         viewModelScope.coroutineContext.cancelChildren()


### PR DESCRIPTION
Includes logic to check whether or not BundleClient is installed in AuthRepository.kt and has a multi-step procedure to call it and update screen.

In order to see the chain of commands, you can continue to go into a chain of implementations from the clientError() method in LoginViewModel.kt

Added ErrorScreen.kt which is called to display the error screen.