### PR TITLE
Error Screen Logic Quick Fix - updated so it only checks for the BundleClient package

### DIFF
--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/repository/AuthRepositoryImpl.kt
@@ -34,7 +34,7 @@ class AuthRepositoryImpl(
     }
 
     override suspend fun checkClientStatus(): Boolean {
-        return dddClientAdapter.getClientId() != null && isBundleClientInstalled(context)
+        return isBundleClientInstalled(context)
     }
 
     private fun isBundleClientInstalled(context: Context): Boolean {


### PR DESCRIPTION
Error Screen Logic Quick Fix - updated so it only checks for the BundleClient package.