### PR TITLE
add locale to login and register ADUs

### DIFF
--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
@@ -10,6 +10,7 @@ import app.k9mail.feature.account.setup.domain.entity.AccountUuid
 import app.k9mail.feature.account.setup.domain.usecase.CreateAccount
 import com.fsck.k9.Account
 import com.fsck.k9.Preferences
+import java.util.Locale
 import kotlinx.coroutines.cancelChildren
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,7 +27,6 @@ import net.discdd.k9.onboarding.ui.login.LoginContract.Effect
 import net.discdd.k9.onboarding.ui.login.LoginContract.Event
 import net.discdd.k9.onboarding.ui.login.LoginContract.State
 import net.discdd.k9.onboarding.util.CreateAccountConstants
-import java.util.Locale
 
 @Suppress("TooManyFunctions")
 class LoginViewModel(

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/login/LoginViewModel.kt
@@ -26,6 +26,7 @@ import net.discdd.k9.onboarding.ui.login.LoginContract.Effect
 import net.discdd.k9.onboarding.ui.login.LoginContract.Event
 import net.discdd.k9.onboarding.ui.login.LoginContract.State
 import net.discdd.k9.onboarding.util.CreateAccountConstants
+import java.util.Locale
 
 @Suppress("TooManyFunctions")
 class LoginViewModel(
@@ -151,6 +152,7 @@ class LoginViewModel(
             mapOf(
                 Pair("email", email),
                 Pair("password", password),
+                Pair("locale", Locale.getDefault().language),
             ),
         )
         viewModelScope.launch {

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/register/RegisterViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/register/RegisterViewModel.kt
@@ -3,6 +3,7 @@ package net.discdd.k9.onboarding.ui.register
 import android.util.Log
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import java.util.Locale
 import kotlinx.coroutines.flow.MutableSharedFlow
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
@@ -17,7 +18,6 @@ import net.discdd.k9.onboarding.repository.AuthRepository.AuthState
 import net.discdd.k9.onboarding.ui.register.RegisterContract.Effect
 import net.discdd.k9.onboarding.ui.register.RegisterContract.Event
 import net.discdd.k9.onboarding.ui.register.RegisterContract.State
-import java.util.Locale
 
 class RegisterViewModel(
     initialState: State = State(),

--- a/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/register/RegisterViewModel.kt
+++ b/feature/dddonboarding/src/main/java/net/discdd/k9/onboarding/ui/register/RegisterViewModel.kt
@@ -17,6 +17,7 @@ import net.discdd.k9.onboarding.repository.AuthRepository.AuthState
 import net.discdd.k9.onboarding.ui.register.RegisterContract.Effect
 import net.discdd.k9.onboarding.ui.register.RegisterContract.Event
 import net.discdd.k9.onboarding.ui.register.RegisterContract.State
+import java.util.Locale
 
 class RegisterViewModel(
     initialState: State = State(),
@@ -88,6 +89,7 @@ class RegisterViewModel(
                             Pair("prefix", prefix),
                             Pair("suffix", suffix),
                             Pair("password", password),
+                            Pair("locale", Locale.getDefault().language),
                         ),
                     ),
                     AuthState.PENDING,


### PR DESCRIPTION
- added locale field to login and register adus so that email templates change according to device language
- works with [DDD pr #812](https://github.com/SJSU-CS-systems-group/DDD/pull/812) to solve [DDD issue #647](https://github.com/SJSU-CS-systems-group/DDD/issues/647)
<div style="display: flex; gap: 10px;">
<img width="40%"  alt="Screenshot_20260501-141653" src="https://github.com/user-attachments/assets/428d9199-6636-422e-a2aa-c76e700ee3f1" />  <img width="40%"  alt="Screenshot_20260501-142518" src="https://github.com/user-attachments/assets/0f4a8758-1cdd-46d8-b093-cc7c20cc9f39" />
</div>